### PR TITLE
Set default connection timeout to match with iOS counterpart

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/network/FileDownloader.java
+++ b/src/android/src/com/nordnetab/chcp/main/network/FileDownloader.java
@@ -70,6 +70,7 @@ public class FileDownloader {
         }
 
         URLConnection connection = downloadUrl.openConnection();
+        connection.setConnectTimeout(60000);
         connection.connect();
 
         InputStream input = new BufferedInputStream(downloadUrl.openStream());

--- a/src/android/src/com/nordnetab/chcp/main/network/JsonDownloader.java
+++ b/src/android/src/com/nordnetab/chcp/main/network/JsonDownloader.java
@@ -68,6 +68,7 @@ abstract class JsonDownloader<T> {
         }
 
         URLConnection urlConnection = url.openConnection();
+        urlConnection.setConnectTimeout(60000);
         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
 
         char data[] = new char[1024];


### PR DESCRIPTION
Android version using `URLConnection` class to fetch config file and download files. If I'm not mistaken, the class has default connection timeout is `0` which is infinite, seems a bit too long for me :)

I'm not Java expert, just blindly adding in so please take a look and let me know if I'm missing something

Cheers
